### PR TITLE
chore: Renovateの設定を追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":timezone(Asia/Tokyo)"
+  ],
+  "schedule": [
+    "after 10am and before 5pm every weekday"
+  ],
+  "dependencyDashboard": true,
+  "automerge": true,
+  "platformAutomerge": true,
+  "major": {
+    "reviewers": [
+      "team:frontend-team"
+    ],
+    "labels": [
+      "DBI",
+      "Frontend"
+    ],
+    "automerge": false,
+    "platformAutomerge": false
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "Security",
+      "DBI",
+      "Frontend"
+    ],
+    "reviewers": [
+      "team:frontend-team"
+    ],
+    "schedule": []
+  }
+}


### PR DESCRIPTION
## 概要
Renovateボットを導入し、依存関係の自動更新を設定しました。

## 変更内容
- `renovate.json` ファイルを追加
- 依存関係の自動更新設定を実装

## 設定詳細
### 基本設定
- ✅ ベストプラクティス設定を継承
- ✅ タイムゾーン: Asia/Tokyo
- ✅ 更新スケジュール: 平日10:00-17:00のみ
- ✅ 依存関係ダッシュボード有効

### 自動マージ
- ✅ マイナー・パッチ更新: 自動マージ有効
- ❌ メジャー更新: 手動レビュー必須（frontend-teamが担当）

### セキュリティ対応
- ✅ 脆弱性アラート有効
- ✅ 即時対応（スケジュール制限なし）
- ✅ frontend-teamへ自動アサイン

## ラベル
- メジャー更新: `DBI`, `Frontend`
- セキュリティアラート: `Security`, `DBI`, `Frontend`

## レビュアー
- frontend-team（メジャー更新・セキュリティアラート時）

## 影響範囲
このリポジトリの依存関係管理が自動化されます。ダウンストリームへの影響はありません。